### PR TITLE
Fix typos in init.el

### DIFF
--- a/init.el
+++ b/init.el
@@ -44,8 +44,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Gagbage collection settings ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(setq gc-cons-thresold (* 100 1000 1000))
-(add-hook 'focus-out 'garbage-collect)
+(setq gc-cons-threshold (* 100 1000 1000))
+(add-hook 'focus-out-hook 'garbage-collect)
 (run-with-idle-timer 5 t 'garbage-collect)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -722,7 +722,7 @@ _p_rev       _u_pper              _=_: upper/lower       _r_esolve
   :straight t
   :init
   (setq lsp-keymap-prefix "C-c l")
-  (setq lsp-auto-gess-mode t)
+  (setq lsp-auto-guess-root t)
   (setq lsp-solargraph-symbols nil)
   (setq lsp-solargraph-folding nil)
   (setq company-minimum-prefix-length 1)


### PR DESCRIPTION
## Summary
- fix garbage collection variable name and hook
- fix LSP auto guess root option

## Testing
- `emacs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862bbe94894832c890bdea4d873d439