### PR TITLE
Fix service instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ and launch emacs, then execute the following commands:
 + `M-x pdf-tools-install`
 + `M-x all-the-icons-install-fonts`
 
-Now you need to copy the `system.d` service file to your `.config` directory and enable the service:
+Now you need to copy the `systemd` service file to your `.config` directory and enable the service:
 
 ```bash
 cp emacs.service ~/.config/systemd/user/


### PR DESCRIPTION
## Summary
- fix the typo in README describing how to copy the `systemd` service file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6862bd4d4f88832c8aacbe491ba0d0da