### PR TITLE
Add ERT test for init.el loading

### DIFF
--- a/tests/init-load-test.el
+++ b/tests/init-load-test.el
@@ -1,0 +1,5 @@
+(require 'ert)
+
+(ert-deftest init-load-test ()
+  "Load init.el without errors."
+  (load-file "init.el"))


### PR DESCRIPTION
## Summary
- add `tests/` directory with a basic ERT test that loads `init.el`

## Testing
- `emacs --batch -l ert -l tests/init-load-test.el -f ert-run-tests-batch-and-exit` *(fails: emacs not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6862bdbf3134832cb73ec87116dce699