### PR TITLE
Fix typo in kill-gpg-buffers docstring

### DIFF
--- a/init.el
+++ b/init.el
@@ -122,7 +122,7 @@
   :config (pinentry-start))
 
 (defun kill-gpg-buffers ()
-  "Kill GPG buffers after a period of innactivity."
+  "Kill GPG buffers after a period of inactivity."
   (interactive)
   (let ((buffers-killed 0))
     (dolist (buffer (buffer-list))


### PR DESCRIPTION
## Summary
- fix the docstring for `kill-gpg-buffers`

## Testing
- `emacs --batch -Q --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile init.el personal-config.el` *(fails: `emacs: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6862bdca226c832c8558b36fa9bcf66a